### PR TITLE
Add JSONL validation test

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -142,6 +142,18 @@ def test_process_images_output(runner, temp_dir):
     jsonl_file = os.path.join(temp_dir, "dataset.jsonl")
     assert os.path.exists(jsonl_file), f"Expected JSONL file not found: {jsonl_file}"
 
+    # Validate JSONL contents
+    entries = []
+    with open(jsonl_file, "r") as f:
+        for line in f:
+            if line.strip():
+                entries.append(json.loads(line))
+
+    assert len(entries) == num_images
+    for entry in entries:
+        for key in ["image", "text", "mask_path"]:
+            assert key in entry
+
     # Print the final contents of the output directory
     print("\nFinal contents of output directory:")
     for file in os.listdir(temp_dir):


### PR DESCRIPTION
## Summary
- ensure generated `dataset.jsonl` is parsed and checked for expected keys

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_687ec326d85c83269094307f60d0823f